### PR TITLE
xmake and parsing fixes

### DIFF
--- a/PapyrusSourceHeadliner/PapyrusSource.cpp
+++ b/PapyrusSourceHeadliner/PapyrusSource.cpp
@@ -1,5 +1,38 @@
 #include "PapyrusSource.h"
 
+namespace {
+
+// Papyrus param lists can span lines; count () outside double-quoted strings and \\ escapes.
+int paren_depth_after_line(const std::string& line, int depth)
+{
+    bool in_dquote = false;
+    for (size_t i = 0; i < line.size(); ++i) {
+        const unsigned char c = static_cast<unsigned char>(line[i]);
+        if (in_dquote) {
+            if (c == '\\' && i + 1 < line.size()) {
+                ++i;
+                continue;
+            }
+            if (c == '"') {
+                in_dquote = false;
+            }
+            continue;
+        }
+        if (c == '"') {
+            in_dquote = true;
+            continue;
+        }
+        if (c == '(') {
+            ++depth;
+        } else if (c == ')' && depth > 0) {
+            --depth;
+        }
+    }
+    return depth;
+}
+
+} // namespace
+
 std::vector<std::string> g_blacklist 
 {
     "endproperty",
@@ -157,9 +190,11 @@ bool PapyrusSource::Process()
 
     temp.open(loc_tmppath);
 
+    _paren_depth = 0;
+    _dontignorenext = false;
     bool loc_ignore = false;
-    
-    while (std::getline(_file, loc_line)) 
+
+    while (std::getline(_file, loc_line))
     {
 
         //change to lowecase and change all tabs to spaces
@@ -172,14 +207,31 @@ bool PapyrusSource::Process()
         //erase gap at start of line
         const std::string loc_delims(" \t"); //white chars
         size_t loc_firstcharpos = loc_line.find_first_not_of(loc_delims);
-        loc_line.erase(loc_line.begin(),loc_line.begin() + loc_firstcharpos);
+        if (loc_firstcharpos == std::string::npos) {
+            loc_line.clear();
+        } else {
+            loc_line.erase(loc_line.begin(), loc_line.begin() + static_cast<std::ptrdiff_t>(loc_firstcharpos));
+        }
 
+        if (_dontignorenext) {
+            _dontignorenext = false;
+            temp << loc_line << std::endl;
+            _paren_depth = paren_depth_after_line(loc_line, _paren_depth);
+            continue;
+        }
+
+        if (_paren_depth > 0) {
+            temp << loc_line << std::endl;
+            _paren_depth = paren_depth_after_line(loc_line, _paren_depth);
+            continue;
+        }
 
         loc_ignore = Filter(loc_line);
 
-        if (!loc_ignore) 
+        if (!loc_ignore)
         {
             temp << loc_line << std::endl;
+            _paren_depth = paren_depth_after_line(loc_line, 0);
         }
  
     }

--- a/PapyrusSourceHeadliner/PapyrusSource.h
+++ b/PapyrusSourceHeadliner/PapyrusSource.h
@@ -24,4 +24,5 @@ class PapyrusSource
         std::string _filename;
         std::string _endpatern = "";
         bool _dontignorenext = false;
+        int _paren_depth = 0;
 };

--- a/xmake.lua
+++ b/xmake.lua
@@ -1,11 +1,7 @@
 add_rules("mode.debug", "mode.release")
 
--- Set default toolchain for Windows cross-compilation
-if is_host("linux") then
-    set_toolchains("gcc")
-    if is_plat("windows") then
-        set_toolchains("mingw")
-    end
+if is_plat("windows") and not is_host("windows") then
+    set_toolchains("mingw")
 end
 
 target("PapyrusSourceHeadliner")
@@ -23,6 +19,12 @@ target("PapyrusSourceHeadliner")
         add_links("pthread")
         add_defines("LINUX")
     end
+
+    on_config(function (target)
+        if target:is_plat("windows") and target:toolchain("mingw") then
+            target:add("ldflags", "-static", {force = true})
+        end
+    end)
 
     add_cxxflags("-Wall", "-Wextra")
     if is_mode("release") then


### PR DESCRIPTION
This PR fixes Windows builds failing to launch due to missing DLLs as well as the headliner breaking scripts when functions had params across multiple lines. Thanks to Exodysseus on Citadel for testing.

Also do a new release plox